### PR TITLE
Make sure the crate is idempotent. Allow options.

### DIFF
--- a/haproxy/src/pallet/crate/haproxy.clj
+++ b/haproxy/src/pallet/crate/haproxy.clj
@@ -110,6 +110,7 @@
         group-name (keyword (session/group-name session))
         srv-apps (-?> session :parameters :haproxy group-name)
         app-keys (keys srv-apps)
+        srv-apps (zipmap app-keys (->> srv-apps vals (map distinct)))
         unconfigured (clojure.set/difference (set app-keys) (set apps))
         no-nodes (clojure.set/difference (set app-keys) (set apps))]
     (when (seq unconfigured)
@@ -181,9 +182,9 @@
       (conj
        (or v [])
        (merge
-        options
         {:ip (session/target-ip session)
-         :name (session/safe-name session)}))))))
+         :name (session/safe-name session)}
+        options))))))
 
 #_
 (pallet.core/defnode haproxy


### PR DESCRIPTION
This commit introduces two changes to the haproxy crate.
First it makes it idempotent, i.e: multiple calls will not result in different changes.
Second it allows the specification of a different target ip for each node calling proxied-by, this is useful on EC2 where load-balancing is often done on internal ips.
